### PR TITLE
refactor(clipboard): 🎉 Clean up imports and module paths! 🛠️

### DIFF
--- a/crates/code2prompt/src/clipboard.rs
+++ b/crates/code2prompt/src/clipboard.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use anyhow::Result;
 
 #[cfg(not(target_os = "linux"))]
 /// Copies the provided text to the system clipboard.
@@ -14,7 +15,6 @@ use anyhow::Context;
 ///
 /// * `Result<()>` - Returns Ok on success, or an error if the clipboard could not be accessed.
 pub fn copy_text_to_clipboard(rendered: &str) -> Result<()> {
-    use anyhow::Result;
     use arboard::Clipboard;
     match Clipboard::new() {
         Ok(mut clipboard) => {

--- a/crates/code2prompt/src/main.rs
+++ b/crates/code2prompt/src/main.rs
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
         }
         #[cfg(not(target_os = "linux"))]
         {
-            use code2prompt::copy_text_to_clipboard;
+            use clipboard::copy_text_to_clipboard;
             match copy_text_to_clipboard(&rendered) {
                 Ok(_) => {
                     println!(


### PR DESCRIPTION
- Moved `anyhow::Result` import to the top in `clipboard.rs` for better readability. 📚
- Updated module path in `main.rs` from `code2prompt::copy_text_to_clipboard` to `clipboard::copy_text_to_clipboard`. 🗂️

These changes make the code more organized and maintainable, ensuring we don't get lost in import spaghetti! 🍝